### PR TITLE
Fix 3scale organization refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Try the [example](examples) on your Docker environment. You'll get the following
 Start by cloning the repo:
 
 ```shell
-git clone git@github.com:3scale/authorino.git
+git clone git@github.com:3scale-labs/authorino.git
 ```
 
 #### 2. Run the services

--- a/pocs/README.md
+++ b/pocs/README.md
@@ -18,5 +18,5 @@ The embryo of Authorino as proposed for the 3scale Ostia architecture.
 **Portafly + Keycloak** · https://github.com/didierofrivia/portafly<br/>
 Demo: using Keycloak to authenticate and authorize requests between a SPA and a node.js resource server.
 
-**Envoy JWT plugin** · https://github.com/3scale/gateway-ng-controller/pull/28<br/>
+**Envoy JWT plugin** · https://github.com/3scale-labs/gateway-ng-controller/pull/28<br/>
 Envoy proxy extension to implement plug-in OIDC-based authentication with JSON Web Tokens (JWT).


### PR DESCRIPTION
Authorino and other experimental projects of 3scale now live in https://github.com/3scale-labs.